### PR TITLE
Setup vagrant box for development quickstart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 /log/*
 !/log/.keep
 /tmp
+*.log
+
+.vagrant/

--- a/README.md
+++ b/README.md
@@ -7,19 +7,48 @@ API for Tvarkau Vilnių apps. Manages problems reported by Vilnius citizens.
 
 ## Getting started
 
-### Running app (using docker)
+### Setting up development environment
+
+#### Option 1: vagrant
+
+_This automatically creates and provisions ubuntu 16.04 based box with needed dev tools. Tested on: OSX Sierra and Windows 10._
+
+Pre-requisites:
+
+- Vagrant
+- VirtualBox 5.1.14
+
+(_Note: at the moment of writing, latest (5.1.16) has a [regression issue](https://www.virtualbox.org/ticket/14651)_)
+
+```
+$ vagrant plugin install vagrant-vbguest
+$ vagrant up
+```
+
+Login into the dev box:
+
+```
+$ vagrant ssh
+```
+
+#### Option 2: native (OSX)
+
+- Install docker
+- Install docker-compose
+- Install [Homebrew](https://brew.sh/)
+- Install [rbenv](https://github.com/rbenv/rbenv#homebrew-on-mac-os-x) 
+- Install [rails 2.3.1](https://gorails.com/setup/osx/10.12-sierra) 
+
+### Running app
+
+Using docker:
 
 ```
 $ docker-compose up
 ```
 
-### Running app (using native ruby)
+Or manually:
 
-Pre-requisites:
-
-- Install [Homebrew](https://brew.sh/)
-- Install [rbenv](https://github.com/rbenv/rbenv#homebrew-on-mac-os-x) 
-- Install [rails 2.3.1](https://gorails.com/setup/osx/10.12-sierra) 
 - Run DB `docker-compose up -d db`
 - `bundle install`
 - Ensure database migrations are up to date

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,91 @@
+$script = <<SCRIPT
+export DEBIAN_FRONTEND=noninteractive
+
+# Fix locale
+echo "
+export LANGUAGE=en_US.utf8
+export LANG=en_US.utf8
+export LC_ALL=en_US.utf8
+">>~/.bashrc
+
+# Use local mirror
+sudo sed -i 's%archive.ubuntu.com%ubuntu.mirror.vu.lt%' /etc/apt/sources.list
+sudo apt-get update -qq
+sudo apt-get upgrade -y
+
+# Pre-requisites
+sudo apt-get install -y \
+  apt-transport-https \
+  ca-certificates \
+  software-properties-common \
+  git-core \
+  curl \
+  zlib1g-dev \
+  build-essential \
+  libssl-dev \
+  libreadline-dev \
+  libyaml-dev \
+  libxml2-dev \
+  libxslt1-dev \
+  libcurl4-openssl-dev \
+  python-software-properties \
+  libffi-dev \
+  libpq-dev \
+  cmake \
+  pkg-config
+
+# Node.js
+curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
+sudo apt-get install -y \
+  nodejs
+
+# docker
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo add-apt-repository -y \
+  "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) \
+  stable"
+sudo apt-get update -qq
+sudo apt-get install -y \
+  docker-ce
+sudo groupadd docker
+sudo usermod -aG docker ubuntu
+sudo systemctl enable docker
+
+# docker-compose
+sudo curl -L "https://github.com/docker/compose/releases/download/1.11.2/docker-compose-$(uname -s)-$(uname -m)" \
+  -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
+
+# Ruby (rbenv)
+git clone https://github.com/rbenv/rbenv.git ~/.rbenv
+echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc
+echo 'eval "$(rbenv init -)"'               >> ~/.bashrc
+source ~/.bashrc
+git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build
+sudo -H -u ubuntu bash -i -c 'rbenv install 2.3.1'
+sudo -H -u ubuntu bash -i -c 'rbenv rehash'
+sudo -H -u ubuntu bash -i -c 'rbenv global 2.3.1'
+sudo -H -u ubuntu bash -i -c 'gem install bundler --no-ri --no-rdoc'
+sudo -H -u ubuntu bash -i -c 'rbenv rehash'
+
+# Change to /vagrant (mounted project dir) upon login
+sudo -H -u ubuntu bash -i -c "echo 'cd /vagrant' >> ~/.bashrc"
+
+echo 'DONE.'
+
+SCRIPT
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/xenial64"
+  config.vm.network "forwarded_port", guest: 3000, host: 3000
+  config.vm.network "forwarded_port", guest: 5432, host: 5432
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.name = "tvarkau-dev-box"
+    vb.memory = "2048"
+    vb.cpus = 2
+  end
+
+  config.vm.provision :shell, privileged: false, inline: $script
+end


### PR DESCRIPTION
Had difficulties running `pronto` on windows because of its dependency on `rugged` which requires building it natively (and IMHO not worth the effort). This vagrant-based dev box (ubuntu based) could be a unified environment, especially for windows users.

And despite the OS, this makes setting up a new dev environment for contributors essentially a one-liner.