### PR TITLE
Add current user endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'rails', '5.1.4'
 gem 'mysql2'
+gem 'active_model_serializers', '~> 0.10'
 gem 'puma', '~> 3.11'
 gem 'aws-sdk', '~> 2'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_model_serializers (0.10.7)
+      actionpack (>= 4.1, < 6)
+      activemodel (>= 4.1, < 6)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (5.1.4)
       activesupport (= 5.1.4)
       globalid (>= 0.3.6)
@@ -62,6 +67,8 @@ GEM
       i18n
       rake (>= 10.0.0)
       sshkit (>= 1.9.0)
+    case_transform (0.2)
+      activesupport
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
     crack (0.4.3)
@@ -107,6 +114,7 @@ GEM
     interactor-initializer (0.2.0)
     jmespath (1.3.1)
     json (2.1.0)
+    jsonapi-renderer (0.2.0)
     jwt (2.1.0)
     koala (3.0.0)
       addressable
@@ -293,6 +301,7 @@ PLATFORMS
   x64-mingw32
 
 DEPENDENCIES
+  active_model_serializers (~> 0.10)
   aws-sdk (~> 2)
   byebug
   capistrano (~> 3.10)

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Api::UsersController < Api::BaseController
+  def show
+    render json: current_user
+  end
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class UserSerializer < ActiveModel::Serializer
+  attributes :id, :email, :created_at
+end

--- a/config/initializers/active_model_serializer.rb
+++ b/config/initializers/active_model_serializer.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+ActiveModel::Serializer.config.adapter = ActiveModelSerializers::Adapter::JsonApi

--- a/config/initializers/active_model_serializer.rb
+++ b/config/initializers/active_model_serializer.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-ActiveModel::Serializer.config.adapter = ActiveModelSerializers::Adapter::JsonApi

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   root 'welcome#index'
 
   namespace :api, constraints: { format: 'json' } do
+    resource :user
     resources :reports
     resources :report_types, only: [:index]
     resources :tokens, only: [:create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   root 'welcome#index'
 
   namespace :api, constraints: { format: 'json' } do
-    resource :user
+    resource :me, controller: :users, only: :show
     resources :reports
     resources :report_types, only: [:index]
     resources :tokens, only: [:create]

--- a/spec/controllers/api/users_controller_spec.rb
+++ b/spec/controllers/api/users_controller_spec.rb
@@ -8,14 +8,9 @@ RSpec.describe Api::UsersController do
       expect(subject).to be_success
 
       expect(response_json).to include(
-        'data' => {
-          'id' => user.id.to_s,
-          'type' => 'users',
-          'attributes' => {
-            'email' => user.email,
-            'created-at' => user.created_at,
-          },
-        }
+        'id' => user.id,
+        'email' => user.email,
+        'created_at' => user.created_at,
       )
     end
   end

--- a/spec/controllers/api/users_controller_spec.rb
+++ b/spec/controllers/api/users_controller_spec.rb
@@ -8,9 +8,14 @@ RSpec.describe Api::UsersController do
       expect(subject).to be_success
 
       expect(response_json).to include(
-        'id' => user.id,
-        'email' => user.email,
-        'created_at' => user.created_at
+        'data' => {
+          'id' => user.id.to_s,
+          'type' => 'users',
+          'attributes' => {
+            'email' => user.email,
+            'created-at' => user.created_at,
+          },
+        }
       )
     end
   end

--- a/spec/controllers/api/users_controller_spec.rb
+++ b/spec/controllers/api/users_controller_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.describe Api::UsersController do
+  describe '#show' do
+    subject { api_get :show }
+
+    it 'returns current user' do
+      expect(subject).to be_success
+
+      expect(response_json).to include(
+        'id' => user.id,
+        'email' => user.email,
+        'created_at' => user.created_at
+      )
+    end
+  end
+end

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -33,6 +33,10 @@ module ApiSpecHelper
   end
 
   def oauth_token
-    @oauth_token ||= create(:oauth_token)
+    @oauth_token ||= create(:oauth_token, user: user)
+  end
+
+  def user
+    @user ||= create(:user)
   end
 end


### PR DESCRIPTION
@mjurkus @tadaskay 

https://github.com/vilnius/tvarkau-vilniu-ms/issues/44

1. I suggest using `/me` endpoint instead of `/user`. It is quite common practice to fetch current user from `/me`. `/user` can be confusing if later we would need to add `/users` endpoint which would allow fetching users list or information about other users.

2. Do we need user's first and last names? Currently only `id`, `email` and `created_at` would be returned.

3. I have set [json-api](http://jsonapi.org/) format for responses. Is it ok? Another option - just plain json `{ 'id': 1, email: 'some@email.com' }`.