### PR TITLE
Adjust reports pagination

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -274,15 +274,15 @@ Android/iOS apps can use custom url scheme to handle return to the application w
 
   [Report][]
 
-## Reports Collection [/reports{?type,status,limit,offset}]
+## Reports Collection [/reports{?type,status,page,per_page}]
 
 ### List Reports [GET]
 
 + Parameters
     + type: 1 (number, optional) - Report type id
     + status: 1 (number, optional) - Report status id
-    + limit: 20 (number, optional) - Returned entries limit
-    + offset: 0 (number, optional) - List offset
+    + page: 2 (number, optional) - Page number
+    + per_page: 20 (number, optional) - Returned entries limit
 
 + Response 200 (application/json)
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -33,6 +33,6 @@ class ReportsController < ApiController
   end
 
   def filter_params
-    params.permit(:start, :limit, :type, :status)
+    params.permit(:page, :per_page, :type, :status)
   end
 end

--- a/app/domain/reports/filter.rb
+++ b/app/domain/reports/filter.rb
@@ -1,6 +1,6 @@
 class Reports::Filter
 
-  DEFAULT_LIMIT = 20
+  DEFAULT_PER_PAGE = 20
 
   def self.for(params)
     new(params).run
@@ -13,7 +13,7 @@ class Reports::Filter
   end
 
   def run
-    scope = Report.offset(offset).limit(limit)
+    scope = Report.offset(offset).limit(per_page)
     scope = scope.where(status_id: params[:status]) if params[:status].present?
     scope = scope.where(report_type_id: params[:type]) if params[:type].present?
     scope.to_a
@@ -21,11 +21,15 @@ class Reports::Filter
 
   private
 
-  def limit
-    params[:limit] || DEFAULT_LIMIT
+  def offset
+    page.to_i * per_page.to_i
   end
 
-  def offset
-    params[:start] || 0
+  def per_page
+    params[:per_page] || DEFAULT_PER_PAGE
+  end
+
+  def page
+    params[:page] || 0
   end
 end

--- a/spec/domain/reports/filter_spec.rb
+++ b/spec/domain/reports/filter_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Reports::Filter, '.for' do
   let!(:report_3) { create(:report, status: postponed, report_type: type_2) }
   let(:params) do
     {
-      limit: 2,
+      per_page: 2,
     }
   end
 


### PR DESCRIPTION
@mjurkus 

There was an error in the documentation with the `offset` param. However, I think it is good idea to have `page` param.  Changed to `page` and `per_page` params.

https://github.com/vilnius/tvarkau-vilniu-ms/issues/77