### PR TITLE
Upgrade doorkeeper and enable client credentials grant

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'active_model_serializers', '~> 0.10'
 gem 'puma', '~> 3.11'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
 gem 'interactor-initializer', '~> 0.2'
-gem 'doorkeeper', '~> 4.2.6'
+gem 'doorkeeper', '~> 4.4.1'
 gem 'devise', '~> 4.4.0'
 gem 'omniauth-google-oauth2', '~> 0.5'
 gem 'omniauth-facebook', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,7 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.3)
-    doorkeeper (4.2.6)
+    doorkeeper (4.4.1)
       railties (>= 4.2)
     dotenv (2.2.1)
     dotenv-rails (2.2.1)
@@ -338,7 +338,7 @@ DEPENDENCIES
   carrierwave (~> 1.2)
   database_cleaner
   devise (~> 4.4.0)
-  doorkeeper (~> 4.2.6)
+  doorkeeper (~> 4.4.1)
   dotenv-rails (~> 2.2)
   factory_bot_rails
   faraday

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -5,10 +5,10 @@ Doorkeeper.configure do
 
   orm :active_record
 
-  grant_flows %w[authorization_code password assertion]
+  grant_flows %w[client_credentials authorization_code password assertion]
 
-  default_scopes :user
-  # optional_scopes :write, :update
+  default_scopes :public
+  optional_scopes :user
 
   resource_owner_from_credentials do
     Auth::ResourceOwnerFromCredentials.run(request)

--- a/db/migrate/20180805121935_add_confidential_to_doorkeeper_application.rb
+++ b/db/migrate/20180805121935_add_confidential_to_doorkeeper_application.rb
@@ -1,0 +1,11 @@
+class AddConfidentialToDoorkeeperApplication < ActiveRecord::Migration[5.1]
+  def change
+    add_column(
+      :oauth_applications,
+      :confidential,
+      :boolean,
+      null: false,
+      default: true # maintaining backwards compatibility: require secrets
+    )
+  end
+end

--- a/db/migrate/20180805123604_o_auth_apps_confidentiality.rb
+++ b/db/migrate/20180805123604_o_auth_apps_confidentiality.rb
@@ -1,0 +1,5 @@
+class OAuthAppsConfidentiality < ActiveRecord::Migration[5.1]
+  def up
+    execute "UPDATE oauth_applications SET confidential=0 AND scopes='public user'"
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,7 +6,8 @@ unless Doorkeeper::Application.exists?(uid: 'android')
     name: 'Android',
     uid: 'android',
     redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
-    scopes: 'user',
+    scopes: 'public user',
+    confidential: false,
   )
 end
 
@@ -15,7 +16,8 @@ unless Doorkeeper::Application.exists?(uid: 'ios')
     name: 'iOS',
     uid: 'ios',
     redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
-    scopes: 'user',
+    scopes: 'public user',
+    confidential: false,
   )
 end
 
@@ -27,7 +29,8 @@ unless Doorkeeper::Application.exists?(uid: 'web')
     uid: 'web',
     secret: Secret['WEB_OAUTH2_SECRET'],
     redirect_uri: redirect_uri,
-    scopes: 'user',
+    scopes: 'public user',
+    confidential: false,
   )
 end
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -102,7 +102,7 @@ CREATE TABLE `PRS_MAIN_CFG` (
   PRIMARY KEY (`ID`),
   KEY `PAGE_SIZE` (`PAGE_SIZE`),
   KEY `IS_ACTIVE` (`IS_ACTIVE`)
-) ENGINE=InnoDB AUTO_INCREMENT=11 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `PRS_PROBLEM_TYPES`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -308,7 +308,7 @@ CREATE TABLE `cities` (
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_cities_on_code` (`code`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `oauth_access_grants`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -349,7 +349,7 @@ CREATE TABLE `oauth_access_tokens` (
   KEY `index_oauth_access_tokens_on_application_id` (`application_id`),
   KEY `index_oauth_access_tokens_on_resource_owner_id` (`resource_owner_id`),
   CONSTRAINT `fk_rails_732cb83ab7` FOREIGN KEY (`application_id`) REFERENCES `oauth_applications` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=11 DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `oauth_applications`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -366,7 +366,7 @@ CREATE TABLE `oauth_applications` (
   `confidential` tinyint(1) NOT NULL DEFAULT '1',
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_oauth_applications_on_uid` (`uid`)
-) ENGINE=InnoDB AUTO_INCREMENT=21 DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB AUTO_INCREMENT=14 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `report_photos`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -381,7 +381,7 @@ CREATE TABLE `report_photos` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_report_photos_on_uuid` (`uuid`),
   KEY `index_report_photos_on_report_id` (`report_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `report_types`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -399,7 +399,7 @@ CREATE TABLE `report_types` (
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
   KEY `index_report_types_on_city_id` (`city_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=9 DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `reports`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -452,7 +452,7 @@ CREATE TABLE `statuses` (
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
   KEY `index_statuses_on_active` (`active`)
-) ENGINE=InnoDB AUTO_INCREMENT=11 DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `users`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -497,7 +497,7 @@ CREATE TABLE `users` (
   UNIQUE KEY `index_users_on_google_id` (`google_id`),
   KEY `index_users_on_guest` (`guest`),
   KEY `index_users_on_city_id` (`city_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=35 DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
@@ -532,6 +532,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20171219193843'),
 ('20180104191653'),
 ('20180112204016'),
-('20180805121935');
+('20180805121935'),
+('20180805123604');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -308,7 +308,7 @@ CREATE TABLE `cities` (
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_cities_on_code` (`code`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `oauth_access_grants`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -363,9 +363,10 @@ CREATE TABLE `oauth_applications` (
   `scopes` varchar(255) NOT NULL DEFAULT '',
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
+  `confidential` tinyint(1) NOT NULL DEFAULT '1',
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_oauth_applications_on_uid` (`uid`)
-) ENGINE=InnoDB AUTO_INCREMENT=18 DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB AUTO_INCREMENT=21 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `report_photos`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -496,7 +497,7 @@ CREATE TABLE `users` (
   UNIQUE KEY `index_users_on_google_id` (`google_id`),
   KEY `index_users_on_guest` (`guest`),
   KEY `index_users_on_city_id` (`city_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=34 DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB AUTO_INCREMENT=35 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
@@ -530,6 +531,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20171216141002'),
 ('20171219193843'),
 ('20180104191653'),
-('20180112204016');
+('20180112204016'),
+('20180805121935');
 
 

--- a/spec/factories/oauth_applications.rb
+++ b/spec/factories/oauth_applications.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
     sequence(:uid) { |n| "app-#{n}" }
     redirect_uri 'urn:ietf:wg:oauth:2.0:oob'
     scopes 'user'
+    confidential false
   end
 end

--- a/spec/factories/oauth_applications.rb
+++ b/spec/factories/oauth_applications.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     sequence(:name) { |n| "OAuth Application #{n}" }
     sequence(:uid) { |n| "app-#{n}" }
     redirect_uri 'urn:ietf:wg:oauth:2.0:oob'
-    scopes 'user'
+    scopes 'public user'
     confidential false
   end
 end

--- a/spec/requests/oauth2_spec.rb
+++ b/spec/requests/oauth2_spec.rb
@@ -20,6 +20,16 @@ RSpec.describe 'OAuth2' do
     end
   end
 
+  describe 'client credentials grant' do
+    subject(:token) { client.client_credentials.get_token }
+
+    it 'gets token' do
+      expect(token).not_to be_expired
+      expect(doorkeeper_token.application).to eq(app)
+      expect(doorkeeper_token.resource_owner_id).to be_nil
+    end
+  end
+
   describe 'password grant' do
     subject(:token) { client.password.get_token(username, password, scope: scope) }
 
@@ -62,6 +72,7 @@ RSpec.describe 'OAuth2' do
       end
     end
 
+    # TODO: remove and replace with client credentials grant
     context 'with guest user' do
       let(:username) { 'guest' }
       let(:scope) { 'user' }


### PR DESCRIPTION
@mjurkus 

New doorkeeper version allows to get token via client credentials grant without password for not confidential apps. It would be much more appropriate way to get anonymous token than password login with the "guest" user. I plan to remove password grant login with "guest" later.