### PR TITLE
Replace guest user login with client credentials grant

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -45,11 +45,11 @@ If you already have an access token which has expired, you can use refresh token
 
 Grant type: `refresh_token`
 
-#### Guest login
+#### Anonymous user token
 
-Grant type: `password`
+Grant type: `client_credentials`
 
-Pass `guest` value as username/password.
+Pass only `client_id`. No need for `client_secret`, `username` or `password`.
 
 #### Web authorization
 
@@ -84,7 +84,7 @@ and pass it to the token endpoint via `assertion` attribute.
 + Attributes
     + `client_id`: android (string, required) - Client app identifier. One of: *android*, *ios*, *web*.
     + `client_secret`: secret123 (string, optional) - Client secret. **Required for authorization_code grant type**.
-    + `grant_type`: password (string, required) - OAuth2 grant type. One of: *password*, *assertion*, *authorization_code*, *refresh_token*.
+    + `grant_type`: password (string, required) - OAuth2 grant type. One of: *client_credentials*, *password*, *assertion*, *authorization_code*, *refresh_token*.
     + `refresh_token`: token123 (string, optional) - Refresh token. **Required for refresh_token grant type**.
     + scope: user (string, optional) - Access scope.
     + username: gediminas@vilnius.lt (string, optional) - User's email address. **Required for password grant type**.
@@ -105,14 +105,12 @@ and pass it to the token endpoint via `assertion` attribute.
 
   [Access Token][]
 
-+ Request Create a guest user token.
++ Request Create an anonymous user token.
 
             {
                 "client_id": "android",
-                "grant_type": "password",
-                "scope": "user",
-                "username": "guest",
-                "password": "guest"
+                "grant_type": "client_credentials",
+                "scope": "public"
             }
 
 + Response 200

--- a/app/domain/auth/resource_owner_from_credentials.rb
+++ b/app/domain/auth/resource_owner_from_credentials.rb
@@ -5,28 +5,12 @@ class Auth::ResourceOwnerFromCredentials
 
   initialize_with :request
 
-  GUEST = 'guest'
-
   def run
-    return guest_user if guest?
-
-    authenticated_user
-  end
-
-  private
-
-  def guest_user
-    Users::CreateGuest.run
-  end
-
-  def authenticated_user
     user = User.find_for_authentication(email: username)
     user if user&.valid_password?(password)
   end
 
-  def guest?
-    username == GUEST
-  end
+  private
 
   def username
     request.params[:username]

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -8,13 +8,23 @@ RSpec.describe ApiController do
   subject { api_get :index }
 
   describe 'authorization' do
-    context 'with valid token' do
+    context 'with valid user token' do
       let(:oauth_token) { create(:oauth_token, user: user) }
       let(:user) { create(:user) }
 
       it 'authorizes' do
         expect(subject).to be_successful
         expect(controller.send(:current_user)).to eq(user)
+      end
+    end
+
+    context 'with valid anonymous token' do
+      let(:oauth_token) { create(:oauth_token) }
+
+      it 'authorizes' do
+        expect(subject).to be_successful
+        expect(controller.send(:current_user)).to be_guest
+        expect(oauth_token.reload.resource_owner_id).to be_present
       end
     end
 

--- a/spec/factories/oauth_tokens.rb
+++ b/spec/factories/oauth_tokens.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     end
 
     application { create(:oauth_application) }
-    scopes 'user'
+    scopes 'public user'
     resource_owner_id { user&.id }
   end
 end

--- a/spec/requests/oauth2_spec.rb
+++ b/spec/requests/oauth2_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe 'OAuth2' do
       expect(token).not_to be_expired
       expect(doorkeeper_token.application).to eq(app)
       expect(doorkeeper_token.resource_owner_id).to be_nil
+      expect(doorkeeper_token.scopes).to eq(['public'])
     end
   end
 
@@ -69,21 +70,6 @@ RSpec.describe 'OAuth2' do
       context 'and invalid password' do
         let(:password) { 'test1234' }
         it_behaves_like 'not creating token'
-      end
-    end
-
-    # TODO: remove and replace with client credentials grant
-    context 'with guest user' do
-      let(:username) { 'guest' }
-      let(:scope) { 'user' }
-
-      it 'gets token' do
-        expect(token).not_to be_expired
-        expect(doorkeeper_token.application).to eq(app)
-
-        user = User.find(doorkeeper_token.resource_owner_id)
-
-        expect(user).to be_guest
       end
     end
   end


### PR DESCRIPTION
@mjurkus 

After merging this PR `password` grant with `guest` login will no longer work. It is replaced by `client_credentials` grant which does not require `username` and `password`. Also `client_secret` is not required for the apps who can't keep secrets (mobile).