### PR TITLE
Add endpoint to migrate reports created as guest user

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -371,3 +371,21 @@ Get report types list for current user city.
                 "photo_thumb_url": "https://url/photo_thumb.jpg"
             }
         }
+
+# Group Guest Migration
+
+## Guest Migration [/guest_migration]
+
+### Migrate guest reports to user [POST]
+
+Reports created by anonymous guest user will be migrated to currently logged in user.
+
++ Attributes
+    + guest_token: token123 (string) - Guest access token
+
++ Response 200 (application/json)
+
+        {
+            "success": true
+        }
+

--- a/app/controllers/guest_migrations_controller.rb
+++ b/app/controllers/guest_migrations_controller.rb
@@ -1,0 +1,17 @@
+class GuestMigrationsController < ApiController
+  class MigrationError < StandardError; end
+
+  def create
+    Users::MigrateGuest.run(current_user, guest_token)
+
+    render json: { success: true }
+  rescue Errors::GuestMigrationError => e
+    render_api_error VALIDATION_ERROR, e.message
+  end
+
+  private
+
+  def guest_token
+    @guest_token ||= Doorkeeper::AccessToken.find_by!(token: params[:guest_token])
+  end
+end

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Errors
+  class Error < StandardError; end
+  class GuestMigrationError < Error; end
+end

--- a/app/domain/users/migrate_guest.rb
+++ b/app/domain/users/migrate_guest.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class Users::MigrateGuest
+  include Interactor::Initializer
+
+  initialize_with :user, :guest_token
+
+  def run
+    return unless guest_token.resource_owner_id
+
+    validate!
+
+    User.transaction do
+      guest_user.reports.update_all(user_id: user.id)
+      guest_user.destroy
+      guest_token.destroy
+    end
+  end
+
+  private
+
+  def validate!
+    raise GuestMigrationError, 'Current user is guest' if user.guest?
+  end
+
+  def guest_user
+    @guest_user ||= User.guests.find_by!(id: guest_token.resource_owner_id)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,8 @@ class User < ApplicationRecord
 
   belongs_to :city, optional: true
 
+  scope :guests, -> { where(guest: true) }
+
   def email_required?
     !guest? && !personal_code?
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,5 +19,6 @@ Rails.application.routes.draw do
     resources :report_types, only: [:index]
     resources :tokens, only: [:create]
     resources :report_photos, only: [:create]
+    resource :guest_migration, only: [:create]
   end
 end

--- a/spec/controllers/guest_migrations_controller_spec.rb
+++ b/spec/controllers/guest_migrations_controller_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe GuestMigrationsController do
+  describe '#create' do
+    subject { api_post :create, params: { guest_token: guest_token.token } }
+
+    let(:guest_token) { create(:oauth_token, user: guest_user) }
+    let(:guest_user) { create(:user, guest: true) }
+    let!(:report) { create(:report, user: guest_user) }
+
+    it 'migrates guest data' do
+      expect { subject }.to change { report.reload.user }.from(guest_user).to(user)
+      expect(subject).to be_successful
+    end
+  end
+end


### PR DESCRIPTION
@mjurkus 

Endpoint: `POST /guest_migration`

After successful registration or login app should call this endpoint and pass guest user access token which was used before signup / login. Reports created by the anonymous user will be migrated to the current user.