### PR TITLE
Reduce auth session timeout

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -171,7 +171,7 @@ Devise.setup do |config|
   # time the user will be asked for credentials again. Default is 30 minutes.
   # config.timeout_in = 30.minutes
   #
-  config.timeout_in = 1.minute
+  config.timeout_in = 5.seconds
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.


### PR DESCRIPTION
@mjurkus 

It can be very low, because in OAuth2 case it would just authenticate user from the API app session during this time (wouldn't ask to authorize again).